### PR TITLE
Implement Discord verification workflow

### DIFF
--- a/src/config/verificationConfig.js
+++ b/src/config/verificationConfig.js
@@ -1,0 +1,22 @@
+module.exports = {
+    VERIFY_CHANNEL_ID: '1402678764923523267',
+    VERIFY_ROLE_ID: '1402678555531284681',
+    TIMEOUT_MS: 60 * 1000,
+    DM_MESSAGE: `⛔ Twoja weryfikacja została odrzucona.
+
+Aby uzyskać dostęp do darmowych rzeczy, musisz **wysłać DWA zdjęcia** potwierdzające wykonanie poniższych kroków:
+
+✅ Obserwacja TikToka: https://www.tiktok.com/@slientmafiatop  
+✅ Subskrypcja + like pod filmem: https://www.youtube.com/watch?v=DOBELRa6apA
+
+Spróbuj ponownie za 1 minutę. Dziękujemy! – Silent Maf1a 🏴‍☠️`,
+    STICKY_MESSAGE: `### <a:yes:1253433659260669975> Verification - maximum 2 minutes.
+
+-# To access our **Free Stuff**, please make sure you have completed **ALL** steps and attached **TWO clear and complete screenshots** as proof:
+
+## <a:Verified_Purple_Animated:1382655410795843695> **Follow us on TikTok:** [www.tiktok.com/@slientmafiatop](https://www.tiktok.com/@slientmafiatop)
+
+## <a:Verified_Purple_Animated:1382655410795843695> **Leave a like & sub on the channel:** [youtube.com/watch?v=DOBELRa6apA](https://www.youtube.com/watch?v=DOBELRa6apA)
+
+-# Thank you for your support - Silent Maf1a <:silent:1395058293432516658>`
+};


### PR DESCRIPTION
## Summary
- add verification message handler to validate two-image submissions and manage pinned guide
- configure channel, role, timeout and DM/sticky messages for verification process

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68938177e2e08322a42d0d92c0f6d523